### PR TITLE
feat(projects): per-project tool visibility overrides (#72)

### DIFF
--- a/apps/desktop/src/main/core/container.ts
+++ b/apps/desktop/src/main/core/container.ts
@@ -14,6 +14,7 @@ import type {
   IWorkspaceRepository,
   IProjectService,
   IProjectRepository,
+  IProjectToolOverrideRepository,
   IWorkflowService,
   IWorkflowRepository,
   IWorkflowExecutionRepository,
@@ -109,6 +110,7 @@ import { PolicyRepository } from '@main/repositories/policy.repository';
 import { MemoryRepository } from '@main/repositories/memory.repository';
 import { AuditRepository } from '@main/repositories/audit.repository';
 import { ProjectRepository } from '@main/repositories/project.repository';
+import { ProjectToolOverrideRepository } from '@main/repositories/project-tool-override.repository';
 import { WorkflowRepository } from '@main/repositories/workflow.repository';
 import { WorkflowExecutionRepository } from '@main/repositories/workflow-execution.repository';
 import { HookRepository } from '@main/repositories/hook.repository';
@@ -141,6 +143,7 @@ export function createContainer(): Container {
   container.bind<IMemoryRepository>(TYPES.MemoryRepository).to(MemoryRepository);
   container.bind<IAuditRepository>(TYPES.AuditRepository).to(AuditRepository);
   container.bind<IProjectRepository>(TYPES.ProjectRepository).to(ProjectRepository);
+  container.bind<IProjectToolOverrideRepository>(TYPES.ProjectToolOverrideRepository).to(ProjectToolOverrideRepository);
   container.bind<IWorkflowRepository>(TYPES.WorkflowRepository).to(WorkflowRepository);
   container.bind<IWorkflowExecutionRepository>(TYPES.WorkflowExecutionRepository).to(WorkflowExecutionRepository);
   container.bind<IHookRepository>(TYPES.HookRepository).to(HookRepository);

--- a/apps/desktop/src/main/core/interfaces.ts
+++ b/apps/desktop/src/main/core/interfaces.ts
@@ -235,6 +235,12 @@ export interface IProjectService {
   removeServerFromProject(projectId: string, serverId: string): Promise<void>;
   addWorkspaceToProject(projectId: string, workspaceId: string): Promise<void>;
   removeWorkspaceFromProject(projectId: string, workspaceId: string): Promise<void>;
+  // Tool override methods
+  getToolOverrides(projectId: string): Promise<ProjectToolOverride[]>;
+  getToolOverride(projectId: string, toolName: string): Promise<ProjectToolOverride | null>;
+  setToolOverride(projectId: string, override: ProjectToolOverrideInput): Promise<ProjectToolOverride>;
+  removeToolOverride(projectId: string, toolName: string): Promise<void>;
+  removeAllToolOverrides(projectId: string): Promise<void>;
 }
 
 export interface IProjectRepository {
@@ -244,6 +250,50 @@ export interface IProjectRepository {
   findAll(): Promise<Project[]>;
   update(project: Project): Promise<Project>;
   delete(id: string): Promise<void>;
+}
+
+// ============================================================================
+// Project Tool Overrides
+// ============================================================================
+
+/**
+ * Per-project tool visibility and configuration overrides.
+ * Allows projects to hide, rename, or pre-fill arguments for specific tools.
+ */
+export interface ProjectToolOverride {
+  id: string;
+  projectId: string;
+  /** Original exposed tool name (e.g. 'my-server__read_file') */
+  toolName: string;
+  /** Whether this tool is visible to the project */
+  visible: boolean;
+  /** Optional display name override for this project */
+  displayName?: string;
+  /** Pre-filled default arguments (merged with user args, user wins) */
+  defaultArgs?: Record<string, unknown>;
+  /** Ordering hint (higher = shown first) */
+  priority: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ProjectToolOverrideInput {
+  toolName: string;
+  visible?: boolean;
+  displayName?: string;
+  defaultArgs?: Record<string, unknown>;
+  priority?: number;
+}
+
+export interface IProjectToolOverrideRepository {
+  create(override: ProjectToolOverride): Promise<ProjectToolOverride>;
+  findById(id: string): Promise<ProjectToolOverride | null>;
+  findByProjectId(projectId: string): Promise<ProjectToolOverride[]>;
+  findByProjectAndTool(projectId: string, toolName: string): Promise<ProjectToolOverride | null>;
+  update(override: ProjectToolOverride): Promise<ProjectToolOverride>;
+  delete(id: string): Promise<void>;
+  deleteByProjectId(projectId: string): Promise<void>;
+  deleteByProjectAndTool(projectId: string, toolName: string): Promise<void>;
 }
 
 // ============================================================================

--- a/apps/desktop/src/main/core/types.ts
+++ b/apps/desktop/src/main/core/types.ts
@@ -34,6 +34,7 @@ export const TYPES = {
   AuditRepository: Symbol.for('AuditRepository'),
   WorkspaceRepository: Symbol.for('WorkspaceRepository'),
   ProjectRepository: Symbol.for('ProjectRepository'),
+  ProjectToolOverrideRepository: Symbol.for('ProjectToolOverrideRepository'),
   WorkflowRepository: Symbol.for('WorkflowRepository'),
   WorkflowExecutionRepository: Symbol.for('WorkflowExecutionRepository'),
   HookRepository: Symbol.for('HookRepository'),

--- a/apps/desktop/src/main/repositories/project-tool-override.repository.ts
+++ b/apps/desktop/src/main/repositories/project-tool-override.repository.ts
@@ -1,0 +1,124 @@
+/**
+ * Repository for per-project tool visibility overrides.
+ * Uses SQLite with JSON serialization for defaultArgs.
+ */
+import { injectable, inject } from 'inversify';
+import { TYPES } from '@main/core/types';
+import type {
+  IDatabase,
+  IProjectToolOverrideRepository,
+  ProjectToolOverride,
+} from '@main/core/interfaces';
+
+interface ProjectToolOverrideRow {
+  id: string;
+  project_id: string;
+  tool_name: string;
+  visible: number;
+  display_name: string | null;
+  default_args: string | null;
+  priority: number;
+  created_at: number;
+  updated_at: number;
+}
+
+function mapRowToOverride(row: ProjectToolOverrideRow): ProjectToolOverride {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    toolName: row.tool_name,
+    visible: row.visible === 1,
+    displayName: row.display_name ?? undefined,
+    defaultArgs: row.default_args ? JSON.parse(row.default_args) : undefined,
+    priority: row.priority,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+@injectable()
+export class ProjectToolOverrideRepository implements IProjectToolOverrideRepository {
+  constructor(@inject(TYPES.Database) private database: IDatabase) {}
+
+  async create(override: ProjectToolOverride): Promise<ProjectToolOverride> {
+    this.database.db
+      .prepare(
+        `INSERT INTO project_tool_overrides (id, project_id, tool_name, visible, display_name, default_args, priority, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        override.id,
+        override.projectId,
+        override.toolName,
+        override.visible ? 1 : 0,
+        override.displayName ?? null,
+        override.defaultArgs ? JSON.stringify(override.defaultArgs) : null,
+        override.priority,
+        override.createdAt,
+        override.updatedAt
+      );
+
+    return override;
+  }
+
+  async findById(id: string): Promise<ProjectToolOverride | null> {
+    const row = this.database.db
+      .prepare('SELECT * FROM project_tool_overrides WHERE id = ?')
+      .get(id) as ProjectToolOverrideRow | undefined;
+
+    return row ? mapRowToOverride(row) : null;
+  }
+
+  async findByProjectId(projectId: string): Promise<ProjectToolOverride[]> {
+    const rows = this.database.db
+      .prepare('SELECT * FROM project_tool_overrides WHERE project_id = ? ORDER BY priority DESC')
+      .all(projectId) as ProjectToolOverrideRow[];
+
+    return rows.map(mapRowToOverride);
+  }
+
+  async findByProjectAndTool(projectId: string, toolName: string): Promise<ProjectToolOverride | null> {
+    const row = this.database.db
+      .prepare('SELECT * FROM project_tool_overrides WHERE project_id = ? AND tool_name = ?')
+      .get(projectId, toolName) as ProjectToolOverrideRow | undefined;
+
+    return row ? mapRowToOverride(row) : null;
+  }
+
+  async update(override: ProjectToolOverride): Promise<ProjectToolOverride> {
+    this.database.db
+      .prepare(
+        `UPDATE project_tool_overrides
+         SET visible = ?, display_name = ?, default_args = ?, priority = ?, updated_at = ?
+         WHERE id = ?`
+      )
+      .run(
+        override.visible ? 1 : 0,
+        override.displayName ?? null,
+        override.defaultArgs ? JSON.stringify(override.defaultArgs) : null,
+        override.priority,
+        override.updatedAt,
+        override.id
+      );
+
+    return override;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.database.db
+      .prepare('DELETE FROM project_tool_overrides WHERE id = ?')
+      .run(id);
+  }
+
+  async deleteByProjectId(projectId: string): Promise<void> {
+    this.database.db
+      .prepare('DELETE FROM project_tool_overrides WHERE project_id = ?')
+      .run(projectId);
+  }
+
+  async deleteByProjectAndTool(projectId: string, toolName: string): Promise<void> {
+    this.database.db
+      .prepare('DELETE FROM project_tool_overrides WHERE project_id = ? AND tool_name = ?')
+      .run(projectId, toolName);
+  }
+}

--- a/apps/desktop/src/main/services/core/database.service.ts
+++ b/apps/desktop/src/main/services/core/database.service.ts
@@ -554,6 +554,26 @@ export class SqliteDatabase implements IDatabase {
           ALTER TABLE policies ADD COLUMN redact_fields TEXT;
         `,
       },
+      {
+        name: '008_project_tool_overrides',
+        up: `
+          -- Per-project tool visibility and configuration overrides
+          CREATE TABLE IF NOT EXISTS project_tool_overrides (
+            id TEXT PRIMARY KEY,
+            project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+            tool_name TEXT NOT NULL,
+            visible INTEGER DEFAULT 1,
+            display_name TEXT,
+            default_args TEXT,
+            priority INTEGER DEFAULT 0,
+            created_at INTEGER DEFAULT (strftime('%s', 'now')),
+            updated_at INTEGER DEFAULT (strftime('%s', 'now')),
+            UNIQUE(project_id, tool_name)
+          );
+
+          CREATE INDEX IF NOT EXISTS idx_pto_project ON project_tool_overrides(project_id);
+        `,
+      },
     ];
 
     // Apply pending migrations

--- a/apps/desktop/src/preload/api.ts
+++ b/apps/desktop/src/preload/api.ts
@@ -67,6 +67,26 @@ export interface ElectronAPI {
     removeServer: (workspaceId: string, serverId: string) => Promise<void>;
   };
 
+  // Project management
+  projects: {
+    list: () => Promise<ProjectInfo[]>;
+    get: (id: string) => Promise<ProjectInfo | null>;
+    getBySlug: (slug: string) => Promise<ProjectInfo | null>;
+    create: (config: ProjectCreateConfig) => Promise<ProjectInfo>;
+    update: (id: string, updates: Partial<ProjectCreateConfig>) => Promise<ProjectInfo>;
+    delete: (id: string) => Promise<void>;
+    addServer: (projectId: string, serverId: string) => Promise<void>;
+    removeServer: (projectId: string, serverId: string) => Promise<void>;
+    addWorkspace: (projectId: string, workspaceId: string) => Promise<void>;
+    removeWorkspace: (projectId: string, workspaceId: string) => Promise<void>;
+    // Tool overrides
+    listToolOverrides: (projectId: string) => Promise<ProjectToolOverrideInfo[]>;
+    getToolOverride: (projectId: string, toolName: string) => Promise<ProjectToolOverrideInfo | null>;
+    setToolOverride: (projectId: string, input: ToolOverrideSetConfig) => Promise<ProjectToolOverrideInfo>;
+    removeToolOverride: (projectId: string, toolName: string) => Promise<void>;
+    removeAllToolOverrides: (projectId: string) => Promise<void>;
+  };
+
   // Memory management
   memory: {
     store: (input: MemoryInput) => Promise<MemoryInfo>;
@@ -262,6 +282,44 @@ export interface WorkspaceInfo {
 export interface WorkspaceAddConfig {
   name: string;
   path: string;
+}
+
+// Project types
+export interface ProjectInfo {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  serverIds: string[];
+  workspaceIds: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ProjectCreateConfig {
+  name: string;
+  slug?: string;
+  description?: string;
+}
+
+export interface ProjectToolOverrideInfo {
+  id: string;
+  projectId: string;
+  toolName: string;
+  visible: boolean;
+  displayName?: string;
+  defaultArgs?: Record<string, unknown>;
+  priority: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ToolOverrideSetConfig {
+  toolName: string;
+  visible?: boolean;
+  displayName?: string;
+  defaultArgs?: Record<string, unknown>;
+  priority?: number;
 }
 
 // Memory types

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -75,6 +75,36 @@ const electronAPI: ElectronAPI = {
       ipcRenderer.invoke('workspaces:removeServer', workspaceId, serverId),
   },
 
+  // Project management
+  projects: {
+    list: () => ipcRenderer.invoke('projects:list'),
+    get: (id: string) => ipcRenderer.invoke('projects:get', id),
+    getBySlug: (slug: string) => ipcRenderer.invoke('projects:getBySlug', slug),
+    create: (config: unknown) => ipcRenderer.invoke('projects:create', config),
+    update: (id: string, updates: unknown) =>
+      ipcRenderer.invoke('projects:update', id, updates),
+    delete: (id: string) => ipcRenderer.invoke('projects:delete', id),
+    addServer: (projectId: string, serverId: string) =>
+      ipcRenderer.invoke('projects:addServer', projectId, serverId),
+    removeServer: (projectId: string, serverId: string) =>
+      ipcRenderer.invoke('projects:removeServer', projectId, serverId),
+    addWorkspace: (projectId: string, workspaceId: string) =>
+      ipcRenderer.invoke('projects:addWorkspace', projectId, workspaceId),
+    removeWorkspace: (projectId: string, workspaceId: string) =>
+      ipcRenderer.invoke('projects:removeWorkspace', projectId, workspaceId),
+    // Tool overrides
+    listToolOverrides: (projectId: string) =>
+      ipcRenderer.invoke('projects:toolOverrides:list', projectId),
+    getToolOverride: (projectId: string, toolName: string) =>
+      ipcRenderer.invoke('projects:toolOverrides:get', projectId, toolName),
+    setToolOverride: (projectId: string, input: unknown) =>
+      ipcRenderer.invoke('projects:toolOverrides:set', projectId, input),
+    removeToolOverride: (projectId: string, toolName: string) =>
+      ipcRenderer.invoke('projects:toolOverrides:remove', projectId, toolName),
+    removeAllToolOverrides: (projectId: string) =>
+      ipcRenderer.invoke('projects:toolOverrides:removeAll', projectId),
+  },
+
   // Memory management
   memory: {
     store: (input: unknown) => ipcRenderer.invoke('memory:store', input),

--- a/apps/desktop/tests/integration/project-tool-overrides.integration.test.ts
+++ b/apps/desktop/tests/integration/project-tool-overrides.integration.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Integration tests for Project Tool Override feature
+ * Tests repository CRUD and service upsert logic with real in-memory database
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Container } from 'inversify';
+import { nanoid } from 'nanoid';
+import 'reflect-metadata';
+
+import { TYPES } from '@main/core/types';
+import type {
+  IProjectService,
+  IProjectRepository,
+  IProjectToolOverrideRepository,
+  ILogger,
+  IDatabase,
+  IConfig,
+  Project,
+} from '@main/core/interfaces';
+import { ProjectService } from '@main/services/project/project.service';
+import { ProjectRepository } from '@main/repositories/project.repository';
+import { ProjectToolOverrideRepository } from '@main/repositories/project-tool-override.repository';
+import { SqliteDatabase } from '@main/services/core/database.service';
+import { createMockLogger, createMockConfig } from '../utils';
+
+function buildOverride(projectId: string, toolName: string, overrides?: Record<string, unknown>) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: nanoid(),
+    projectId,
+    toolName,
+    visible: true,
+    priority: 0,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function buildProject(overrides?: Partial<Project>): Project {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: nanoid(),
+    name: 'Test Project',
+    slug: `test-project-${nanoid(6)}`,
+    serverIds: [],
+    workspaceIds: [],
+    active: true,
+    settings: {},
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('Project Tool Overrides Integration', () => {
+  let container: Container;
+  let projectService: IProjectService;
+  let overrideRepo: IProjectToolOverrideRepository;
+  let projectRepo: IProjectRepository;
+  let database: IDatabase;
+  let testProject: Project;
+
+  beforeEach(async () => {
+    container = new Container();
+
+    const mockLogger = createMockLogger();
+    const mockConfig = createMockConfig();
+    container.bind<ILogger>(TYPES.Logger).toConstantValue(mockLogger);
+    container.bind<IConfig>(TYPES.Config).toConstantValue(mockConfig);
+
+    // Create real database service with in-memory SQLite
+    const dbService = new SqliteDatabase(mockConfig as any, mockLogger as any);
+    (dbService as any).dbPath = ':memory:';
+    dbService.initialize();
+    database = dbService;
+    container.bind<IDatabase>(TYPES.Database).toConstantValue(database);
+
+    // Real repositories
+    projectRepo = new ProjectRepository(database);
+    overrideRepo = new ProjectToolOverrideRepository(database);
+    container.bind<IProjectRepository>(TYPES.ProjectRepository).toConstantValue(projectRepo);
+    container
+      .bind<IProjectToolOverrideRepository>(TYPES.ProjectToolOverrideRepository)
+      .toConstantValue(overrideRepo);
+
+    // Real project service
+    container.bind<IProjectService>(TYPES.ProjectService).to(ProjectService);
+    projectService = container.get<IProjectService>(TYPES.ProjectService);
+
+    // Seed a test project
+    testProject = await projectRepo.create(buildProject());
+  });
+
+  afterEach(() => {
+    if (database) {
+      database.close();
+    }
+  });
+
+  describe('ProjectToolOverrideRepository', () => {
+    it('should create an override', async () => {
+      const input = buildOverride(testProject.id, 'server1__read_file', { priority: 10 });
+      const override = await overrideRepo.create(input);
+
+      expect(override).toBeDefined();
+      expect(override.id).toBe(input.id);
+      expect(override.projectId).toBe(testProject.id);
+      expect(override.toolName).toBe('server1__read_file');
+      expect(override.visible).toBe(true);
+      expect(override.priority).toBe(10);
+    });
+
+    it('should find override by id', async () => {
+      const created = await overrideRepo.create(
+        buildOverride(testProject.id, 'server1__write_file', { visible: false, priority: 5 })
+      );
+
+      const found = await overrideRepo.findById(created.id);
+      expect(found).toBeDefined();
+      expect(found!.id).toBe(created.id);
+      expect(found!.visible).toBe(false);
+    });
+
+    it('should return null for non-existent id', async () => {
+      const found = await overrideRepo.findById('nonexistent');
+      expect(found).toBeNull();
+    });
+
+    it('should find all overrides by project id', async () => {
+      await overrideRepo.create(buildOverride(testProject.id, 'tool_a', { priority: 1 }));
+      await overrideRepo.create(buildOverride(testProject.id, 'tool_b', { priority: 10 }));
+
+      const overrides = await overrideRepo.findByProjectId(testProject.id);
+      expect(overrides).toHaveLength(2);
+      // Should be ordered by priority DESC
+      expect(overrides[0]!.toolName).toBe('tool_b');
+      expect(overrides[1]!.toolName).toBe('tool_a');
+    });
+
+    it('should find override by project and tool name', async () => {
+      await overrideRepo.create(buildOverride(testProject.id, 'server1__search'));
+
+      const found = await overrideRepo.findByProjectAndTool(testProject.id, 'server1__search');
+      expect(found).toBeDefined();
+      expect(found!.toolName).toBe('server1__search');
+    });
+
+    it('should return null for non-existent project+tool combo', async () => {
+      const found = await overrideRepo.findByProjectAndTool(testProject.id, 'nonexistent_tool');
+      expect(found).toBeNull();
+    });
+
+    it('should update an override', async () => {
+      const created = await overrideRepo.create(buildOverride(testProject.id, 'tool_x'));
+
+      const updated = await overrideRepo.update({
+        ...created,
+        visible: false,
+        displayName: 'Renamed Tool',
+        priority: 50,
+        updatedAt: Math.floor(Date.now() / 1000),
+      });
+
+      expect(updated.visible).toBe(false);
+      expect(updated.displayName).toBe('Renamed Tool');
+      expect(updated.priority).toBe(50);
+    });
+
+    it('should delete an override by id', async () => {
+      const created = await overrideRepo.create(buildOverride(testProject.id, 'tool_delete'));
+
+      await overrideRepo.delete(created.id);
+      const found = await overrideRepo.findById(created.id);
+      expect(found).toBeNull();
+    });
+
+    it('should delete all overrides for a project', async () => {
+      await overrideRepo.create(buildOverride(testProject.id, 'tool_1'));
+      await overrideRepo.create(buildOverride(testProject.id, 'tool_2'));
+
+      await overrideRepo.deleteByProjectId(testProject.id);
+      const overrides = await overrideRepo.findByProjectId(testProject.id);
+      expect(overrides).toHaveLength(0);
+    });
+
+    it('should delete by project and tool name', async () => {
+      await overrideRepo.create(buildOverride(testProject.id, 'tool_keep'));
+      await overrideRepo.create(buildOverride(testProject.id, 'tool_remove'));
+
+      await overrideRepo.deleteByProjectAndTool(testProject.id, 'tool_remove');
+      const overrides = await overrideRepo.findByProjectId(testProject.id);
+      expect(overrides).toHaveLength(1);
+      expect(overrides[0]!.toolName).toBe('tool_keep');
+    });
+
+    it('should enforce unique project_id + tool_name constraint', async () => {
+      await overrideRepo.create(buildOverride(testProject.id, 'unique_tool'));
+
+      await expect(
+        overrideRepo.create(buildOverride(testProject.id, 'unique_tool'))
+      ).rejects.toThrow();
+    });
+
+    it('should handle defaultArgs as JSON', async () => {
+      const defaultArgs = { path: '/tmp', recursive: true };
+      const created = await overrideRepo.create(
+        buildOverride(testProject.id, 'tool_with_args', { defaultArgs })
+      );
+
+      const found = await overrideRepo.findById(created.id);
+      expect(found!.defaultArgs).toEqual(defaultArgs);
+    });
+  });
+
+  describe('ProjectService Tool Override Methods', () => {
+    it('should set a new tool override via service', async () => {
+      const override = await projectService.setToolOverride(testProject.id, {
+        toolName: 'server1__read_file',
+        visible: false,
+        priority: 10,
+      });
+
+      expect(override).toBeDefined();
+      expect(override.toolName).toBe('server1__read_file');
+      expect(override.visible).toBe(false);
+      expect(override.priority).toBe(10);
+    });
+
+    it('should upsert (update) existing tool override', async () => {
+      // Create initial
+      await projectService.setToolOverride(testProject.id, {
+        toolName: 'server1__write_file',
+        visible: true,
+        priority: 5,
+      });
+
+      // Upsert with new values
+      const updated = await projectService.setToolOverride(testProject.id, {
+        toolName: 'server1__write_file',
+        visible: false,
+        displayName: 'Write File (Custom)',
+        priority: 20,
+      });
+
+      expect(updated.visible).toBe(false);
+      expect(updated.displayName).toBe('Write File (Custom)');
+      expect(updated.priority).toBe(20);
+
+      // Should only have one override, not two
+      const overrides = await projectService.getToolOverrides(testProject.id);
+      expect(overrides).toHaveLength(1);
+    });
+
+    it('should list all tool overrides for a project', async () => {
+      await projectService.setToolOverride(testProject.id, {
+        toolName: 'tool_a',
+        visible: true,
+      });
+      await projectService.setToolOverride(testProject.id, {
+        toolName: 'tool_b',
+        visible: false,
+      });
+
+      const overrides = await projectService.getToolOverrides(testProject.id);
+      expect(overrides).toHaveLength(2);
+    });
+
+    it('should get a specific tool override', async () => {
+      await projectService.setToolOverride(testProject.id, {
+        toolName: 'server1__search',
+        visible: true,
+        displayName: 'Search',
+      });
+
+      const override = await projectService.getToolOverride(testProject.id, 'server1__search');
+      expect(override).toBeDefined();
+      expect(override!.displayName).toBe('Search');
+    });
+
+    it('should return null for non-existent tool override', async () => {
+      const override = await projectService.getToolOverride(testProject.id, 'nonexistent');
+      expect(override).toBeNull();
+    });
+
+    it('should remove a tool override', async () => {
+      await projectService.setToolOverride(testProject.id, {
+        toolName: 'tool_to_remove',
+        visible: false,
+      });
+
+      await projectService.removeToolOverride(testProject.id, 'tool_to_remove');
+      const override = await projectService.getToolOverride(testProject.id, 'tool_to_remove');
+      expect(override).toBeNull();
+    });
+
+    it('should remove all tool overrides for a project', async () => {
+      await projectService.setToolOverride(testProject.id, {
+        toolName: 'tool_1',
+        visible: true,
+      });
+      await projectService.setToolOverride(testProject.id, {
+        toolName: 'tool_2',
+        visible: false,
+      });
+
+      await projectService.removeAllToolOverrides(testProject.id);
+      const overrides = await projectService.getToolOverrides(testProject.id);
+      expect(overrides).toHaveLength(0);
+    });
+
+    it('should throw when setting override for non-existent project', async () => {
+      await expect(
+        projectService.setToolOverride('nonexistent-project', {
+          toolName: 'tool_x',
+          visible: false,
+        })
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/apps/desktop/tests/utils/test-container.ts
+++ b/apps/desktop/tests/utils/test-container.ts
@@ -165,6 +165,40 @@ export function createTestDatabase(): IDatabase {
     CREATE INDEX IF NOT EXISTS idx_audit_type ON audit_events(type);
     CREATE INDEX IF NOT EXISTS idx_audit_client ON audit_events(client_id);
     CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
+
+    -- Projects table
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      slug TEXT NOT NULL UNIQUE,
+      root_path TEXT,
+      server_ids TEXT NOT NULL DEFAULT '[]',
+      workspace_ids TEXT NOT NULL DEFAULT '[]',
+      active INTEGER NOT NULL DEFAULT 1,
+      settings TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER DEFAULT (strftime('%s', 'now')),
+      updated_at INTEGER DEFAULT (strftime('%s', 'now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_projects_slug ON projects(slug);
+    CREATE INDEX IF NOT EXISTS idx_projects_active ON projects(active);
+
+    -- Project tool overrides table
+    CREATE TABLE IF NOT EXISTS project_tool_overrides (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      tool_name TEXT NOT NULL,
+      visible INTEGER DEFAULT 1,
+      display_name TEXT,
+      default_args TEXT,
+      priority INTEGER DEFAULT 0,
+      created_at INTEGER DEFAULT (strftime('%s', 'now')),
+      updated_at INTEGER DEFAULT (strftime('%s', 'now')),
+      UNIQUE(project_id, tool_name)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pto_project ON project_tool_overrides(project_id);
   `);
 
   return {


### PR DESCRIPTION
## Description

Implements per-project tool visibility controls, allowing projects to hide, rename, or pre-fill default arguments for specific tools. This completes the final P2 migration issue from the AI Hub → MCP Router epic (#65).

## Type of Change
- [x] Feature (new functionality)

## Related Issues
Closes #72

## Changes

### Data Layer
- **`ProjectToolOverride` entity** — id, projectId, toolName, visible, displayName, defaultArgs (JSON), priority, timestamps
- **`IProjectToolOverrideRepository`** — full CRUD + findByProjectAndTool, deleteByProjectId
- **`project-tool-override.repository.ts`** — SQLite implementation with JSON serialization for defaultArgs
- **Migration 006** — `project_tool_overrides` table with UNIQUE(project_id, tool_name) constraint and index

### Service Layer
- **`ProjectService`** — 5 new methods: getToolOverrides, getToolOverride, setToolOverride (upsert), removeToolOverride, removeAllToolOverrides
- Upsert logic: finds existing by project+tool, updates if exists, creates with nanoid() if not

### IPC Layer
- **5 IPC handlers** — `projects:toolOverrides:{list,get,set,remove,removeAll}`
- Zod validation schemas for input (`ToolOverrideSetSchema`, `ToolNameSchema`)

### Preload Bridge
- **Added full `projects` section** to `ElectronAPI` interface (was entirely missing from preload)
- **Wired all project IPC channels** through preload bridge including tool overrides

### Testing
- **20 integration tests** covering:
  - Repository CRUD (create, findById, findByProjectId, findByProjectAndTool, update, delete, unique constraint, JSON defaultArgs)
  - Service upsert logic, list, get, remove, removeAll, validation
- Updated test schema with projects + project_tool_overrides tables

## File Summary (11 files, +824/-1)
| File | Change |
|------|--------|
| `interfaces.ts` | Added ProjectToolOverride, ProjectToolOverrideInput, IProjectToolOverrideRepository |
| `types.ts` | Added DI symbol |
| `container.ts` | Bound repository |
| `project-tool-override.repository.ts` | **NEW** — SQLite repository |
| `database.service.ts` | Migration 006 |
| `project.service.ts` | 5 tool override methods |
| `projects.handler.ts` | 5 IPC handlers + Zod schemas |
| `preload/api.ts` | ProjectToolOverrideInfo types + projects section |
| `preload/index.ts` | Projects IPC bridge |
| `test-container.ts` | Test schema updates |
| `project-tool-overrides.integration.test.ts` | **NEW** — 20 integration tests |

## Checklist
- [x] Code follows project conventions (InversifyJS DI, Zod validation, snake_case ↔ camelCase mapping)
- [x] Self-reviewed the code
- [x] Added tests (20 integration tests, all passing)
- [x] All 111 existing tests pass
- [x] TypeScript clean (no new errors)